### PR TITLE
Update readme to include default styles instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ document.body.appendChild(pond.element);
 ```
  The preview will become active when uploading an video or audio file.
 
+Be sure to include this lib's styles, by importing the minified css
+```
+    import 'filepond-plugin-media-preview/dist/filepond-plugin-media-preview.min.css';
+```
 
 ## Demo
 [View the demo](https://nielsboogaard.github.io/filepond-plugin-media-preview/)

--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ document.body.appendChild(pond.element);
 ```
  The preview will become active when uploading an video or audio file.
 
+## Default styles
 Be sure to include this lib's styles, by importing the minified css
-```
-    import 'filepond-plugin-media-preview/dist/filepond-plugin-media-preview.min.css';
+```js
+import 'filepond-plugin-media-preview/dist/filepond-plugin-media-preview.min.css';
 ```
 
 ## Demo

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ document.body.appendChild(pond.element);
  The preview will become active when uploading an video or audio file.
 
 ## Default styles
-Be sure to include this lib's styles, by importing the minified css
+Be sure to include this lib's styles, by importing the minified css.
 ```js
 import 'filepond-plugin-media-preview/dist/filepond-plugin-media-preview.min.css';
 ```


### PR DESCRIPTION
Without this line of code
`import 'filepond-plugin-media-preview/dist/filepond-plugin-media-preview.min.css';`

I get this, 
![image](https://user-images.githubusercontent.com/30238579/98747111-dae49200-2384-11eb-8028-679d73d55a53.png)

with the styles imported, I get this beautiful styling
![image](https://user-images.githubusercontent.com/30238579/98747183-07001300-2385-11eb-93f6-779939f3e25e.png)

